### PR TITLE
Include Unix dependency in package metadata

### DIFF
--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 description = "Multi-word compare-and-swap library"
 version = "%%VERSION_NUM%%"
-requires = ""
+requires = "unix"
 archive(byte) = "kcas.cma"
 archive(native) = "kcas.cmxa"
 plugin(byte) = "kcas.cma"


### PR DESCRIPTION
Including "unix" in the dependencies is necessary so that when the library is used, the linking can proceed correctly.

Fixes #2.